### PR TITLE
Expand twitter timeline behavior to include signed in users timeline (twitter.com/?) and API no return duplicates

### DIFF
--- a/api/lookupWorker.js
+++ b/api/lookupWorker.js
@@ -211,10 +211,10 @@ function allBehaviorInfo(msg) {
 function behaviorList(msg) {
   const replyObj = createReplyObj(msg);
   try {
-    replyObj.results = [
-      findBehavior(msg.query),
-      behaviorMetadata.defaultBehavior,
-    ];
+    const foundBehavior = findBehavior(msg.query);
+    replyObj.results = foundBehavior.defaultBehavior
+      ? [foundBehavior]
+      : [foundBehavior, behaviorMetadata.defaultBehavior];
   } catch (error) {
     replyObj.wasError = true;
     replyObj.errorMsg = error.message;

--- a/behaviors/autoscroll.js
+++ b/behaviors/autoscroll.js
@@ -3,7 +3,7 @@ import * as lib from '../lib';
 let timesScrolled = 0;
 const maxScroll = 100;
 
-async function* scroll() {
+export async function* scroll() {
   let scrollCount = 0;
   while (lib.canScrollMore() && scrollCount < maxScroll) {
     scrollCount++;

--- a/behaviors/twitter/hashTags.js
+++ b/behaviors/twitter/hashTags.js
@@ -5,6 +5,7 @@ import {
   selectors,
   threadedTweetXpath,
 } from './shared';
+import autoScrollBehavior from '../autoscroll';
 
 let behaviorStyle;
 if (debug) {
@@ -154,7 +155,10 @@ export default async function* hashTagIterator(cliAPI) {
   const originalBaseURI = document.baseURI;
   const streamItems = lib.qs(selectors.tweetStreamItems);
   if (!streamItems) {
-    yield lib.stateWithMsgNoWait('Could not find the tweets');
+    yield lib.stateWithMsgNoWait(
+      'Could not find the tweets defaulting to auto scroll'
+    );
+    yield* autoScrollBehavior();
     return;
   }
   yield* lib.traverseChildrenOfLoaderParent(

--- a/behaviors/twitter/timeline.js
+++ b/behaviors/twitter/timeline.js
@@ -1,5 +1,6 @@
 import * as lib from '../../lib';
 import { elemIds, overlayTweetXpath, selectors, tweetXpath } from './shared';
+import autoScrollBehavior from '../autoscroll';
 
 let behaviorStyle;
 if (debug) {
@@ -131,11 +132,18 @@ async function* handleTweet(tweetLi, { originalBaseURI }) {
  *      - GOTO S2
  *
  * @param {Object} cliApi
- * @return {AsyncIterator<boolean>}
+ * @return {AsyncIterator<*>}
  */
 export default async function* timelineIterator(cliApi) {
   const originalBaseURI = document.baseURI;
   const streamItems = lib.qs(selectors.tweetStreamItems);
+  if (!streamItems) {
+    yield lib.stateWithMsgNoWait(
+      'Could not find the tweets defaulting to auto scroll'
+    );
+    yield* autoScrollBehavior();
+    return;
+  }
   // for each post row view the posts it contains
   yield* lib.traverseChildrenOfLoaderParent(streamItems, handleTweet, {
     xpg: cliApi.$x,
@@ -146,7 +154,7 @@ export default async function* timelineIterator(cliApi) {
 export const metaData = {
   name: 'twitterTimelineBehavior',
   match: {
-    regex: /^(?:https:\/\/(?:www\.)?)?twitter\.com\/[^/]+$/,
+    regex: /^(?:https:[/]{2}(?:www[.])?)?twitter[.]com[/]?(?:[^/]+[/]?)?$/,
   },
   description:
     'For each tweet within the timeline views each tweet. If the tweet has a video it is played. If the tweet is a part of a thread or has replies views all related tweets',

--- a/test/helpers/testedValues.js
+++ b/test/helpers/testedValues.js
@@ -1,235 +1,425 @@
-module.exports = [
-  {
-    name: 'Autoscroll',
-    infoURL: 'http://localhost:3030/info?url=https://example.com',
-    infoByNameURL: 'http://localhost:3030/info?name=autoScrollBehavior',
-    behaviorURL: 'http://localhost:3030/behavior?url=https://example.com',
-    behaviorByNameURL: 'http://localhost:3030/behavior?name=autoScrollBehavior',
-    metadata: {
-      name: 'autoScrollBehavior',
-      defaultBehavior: true,
-      description:
-        'Scrolls the page until we can scroll no more. If media elements are discovered while scrolling they are played',
-      fileName: 'autoscrollBehavior.js',
-    },
-    url: 'https://example.com',
-  },
-  {
-    name: 'Deathimitateslanguage',
-    infoURL:
-      'http://localhost:3030/info?url=https://deathimitateslanguage.harmvandendorpel.com',
-    infoByNameURL:
-      'http://localhost:3030/info?name=deathImitatesLanguageBehavior',
-    behaviorURL:
-      'http://localhost:3030/behavior?url=https://deathimitateslanguage.harmvandendorpel.com',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=deathImitatesLanguageBehavior',
-    metadata: {
-      name: 'deathImitatesLanguageBehavior',
-      match: {
-        regex:
-          '^(?:https?:\\/\\/(?:www\\.)?)?deathimitateslanguage\\.harmvandendorpel\\.com\\/?$',
+module.exports = {
+  tests: [
+    {
+      name: 'Autoscroll',
+      metadata: {
+        name: 'autoScrollBehavior',
+        defaultBehavior: true,
+        description:
+          'Scrolls the page until we can scroll no more. If media elements are discovered while scrolling they are played',
+        fileName: 'autoscrollBehavior.js',
       },
-      description:
-        'Scrolls the page clicking all the images rendered at the current scroll level',
-      fileName: 'deathImitatesLanguageBehavior.js',
+      url: 'https://example.com',
+      infoURL: 'http://localhost:3030/info?url=https://example.com',
+      infoByNameURL: 'http://localhost:3030/info?name=autoScrollBehavior',
+      infoListURL: 'http://localhost:3030/info-list?url=https://example.com',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=autoScrollBehavior',
+      behaviorURL: 'http://localhost:3030/behavior?url=https://example.com',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=autoScrollBehavior',
     },
-    url: 'https://deathimitateslanguage.harmvandendorpel.com',
-  },
-  {
-    name: 'Slideshare',
-    infoURL:
-      'http://localhost:3030/info?url=https://www.slideshare.net/annaperricci?utm_campaign=profiletracking&utm_medium=sssite&utm_source=ssslideview',
-    infoByNameURL: 'http://localhost:3030/info?name=slideShareBehavior',
-    behaviorURL:
-      'http://localhost:3030/behavior?url=https://www.slideshare.net/annaperricci?utm_campaign=profiletracking&utm_medium=sssite&utm_source=ssslideview',
-    behaviorByNameURL: 'http://localhost:3030/behavior?name=slideShareBehavior',
-    metadata: {
-      name: 'slideShareBehavior',
-      match: {
-        regex: '^(?:https:\\/\\/(?:www\\.)?)slideshare\\.net\\/[a-zA-Z]+[?].+',
+    {
+      name: 'Deathimitateslanguage',
+      metadata: {
+        name: 'deathImitatesLanguageBehavior',
+        match: {
+          regex:
+            '^(?:https?:\\/\\/(?:www\\.)?)?deathimitateslanguage\\.harmvandendorpel\\.com\\/?$',
+        },
+        description:
+          'Scrolls the page clicking all the images rendered at the current scroll level',
+        fileName: 'deathImitatesLanguageBehavior.js',
       },
-      description:
-        'Views each slide contained in the slide deck. If there are multiple slide decks each deck is viewed',
-      fileName: 'slideShareBehavior.js',
+      url: 'https://deathimitateslanguage.harmvandendorpel.com',
+      infoURL:
+        'http://localhost:3030/info?url=https://deathimitateslanguage.harmvandendorpel.com',
+      infoByNameURL:
+        'http://localhost:3030/info?name=deathImitatesLanguageBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://deathimitateslanguage.harmvandendorpel.com',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=deathImitatesLanguageBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://deathimitateslanguage.harmvandendorpel.com',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=deathImitatesLanguageBehavior',
     },
-    url:
-      'https://www.slideshare.net/annaperricci?utm_campaign=profiletracking&utm_medium=sssite&utm_source=ssslideview',
-  },
-  {
-    name: 'Youtube',
-    infoURL:
-      'http://localhost:3030/info?url=https://www.youtube.com/watch?v=MfH0oirdHLs',
-    infoByNameURL: 'http://localhost:3030/info?name=youtubeVideoBehavior',
-    behaviorURL:
-      'http://localhost:3030/behavior?url=https://www.youtube.com/watch?v=MfH0oirdHLs',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=youtubeVideoBehavior',
-    metadata: {
-      name: 'youtubeVideoBehavior',
-      match: {
-        regex: '^(?:https:\\/\\/(?:www\\.)?)?youtube\\.com\\/watch[?]v=.+',
+    {
+      name: 'Slideshare',
+      metadata: {
+        name: 'slideShareBehavior',
+        match: {
+          regex:
+            '^(?:https:\\/\\/(?:www\\.)?)slideshare\\.net\\/[a-zA-Z]+[?].+',
+        },
+        description:
+          'Views each slide contained in the slide deck. If there are multiple slide decks each deck is viewed',
+        fileName: 'slideShareBehavior.js',
       },
-      description: 'Plays a YouTube video and loads all comments',
-      fileName: 'youtubeVideoBehavior.js',
+      url:
+        'https://www.slideshare.net/annaperricci?utm_campaign=profiletracking&utm_medium=sssite&utm_source=ssslideview',
+      infoURL:
+        'http://localhost:3030/info?url=https://www.slideshare.net/annaperricci?utm_campaign=profiletracking&utm_medium=sssite&utm_source=ssslideview',
+      infoByNameURL: 'http://localhost:3030/info?name=slideShareBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://www.slideshare.net/annaperricci?utm_campaign=profiletracking&utm_medium=sssite&utm_source=ssslideview',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=slideShareBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://www.slideshare.net/annaperricci?utm_campaign=profiletracking&utm_medium=sssite&utm_source=ssslideview',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=slideShareBehavior',
     },
-    url: 'https://www.youtube.com/watch?v=MfH0oirdHLs',
-  },
-  {
-    name: 'Facebook Newsfeed',
-    infoURL: 'http://localhost:3030/info?url=https://www.facebook.com',
-    infoByNameURL: 'http://localhost:3030/info?url=https://www.facebook.com',
-    behaviorURL: 'http://localhost:3030/behavior?name=facebookNewsFeed',
-    behaviorByNameURL: 'http://localhost:3030/behavior?name=facebookNewsFeed',
-    metadata: {
-      name: 'facebookNewsFeed',
-      match: {
-        regex: '^https:\\/\\/(www\\.)?facebook\\.com(\\/)?([?]sk=nf)?$',
+    {
+      name: 'Youtube',
+      metadata: {
+        name: 'youtubeVideoBehavior',
+        match: {
+          regex: '^(?:https:\\/\\/(?:www\\.)?)?youtube\\.com\\/watch[?]v=.+',
+        },
+        description: 'Plays a YouTube video and loads all comments',
+        fileName: 'youtubeVideoBehavior.js',
       },
-      description: 'Views all items in the Facebook news feed',
-      fileName: 'facebookNewsFeedBehavior.js',
+      url: 'https://www.youtube.com/watch?v=MfH0oirdHLs',
+      infoURL:
+        'http://localhost:3030/info?url=https://www.youtube.com/watch?v=MfH0oirdHLs',
+      infoByNameURL: 'http://localhost:3030/info?name=youtubeVideoBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://www.youtube.com/watch?v=MfH0oirdHLs',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=youtubeVideoBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://www.youtube.com/watch?v=MfH0oirdHLs',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=youtubeVideoBehavior',
     },
-    url: 'https://www.facebook.com',
-  },
-  {
-    name: 'Facebook Userfeed',
-    infoURL:
-      'http://localhost:3030/info?url=https://www.facebook.com/Smithsonian/',
-    infoByNameURL:
-      'http://localhost:3030/info?url=https://www.facebook.com/Smithsonian/',
-    behaviorURL: 'http://localhost:3030/behavior?name=facebookUserFeed',
-    behaviorByNameURL: 'http://localhost:3030/behavior?name=facebookUserFeed',
-    metadata: {
-      name: 'facebookUserFeed',
-      match: {
-        regex: '^https:\\/\\/(www\\.)?facebook\\.com\\/[^\\/]+\\/?$',
+    {
+      name: 'Facebook Newsfeed',
+      metadata: {
+        name: 'facebookNewsFeed',
+        match: {
+          regex: '^https:\\/\\/(www\\.)?facebook\\.com(\\/)?([?]sk=nf)?$',
+        },
+        description: 'Views all items in the Facebook news feed',
+        fileName: 'facebookNewsFeedBehavior.js',
       },
-      description:
-        'Views all items in the Facebook user/organization/artists/etc timeline',
-      fileName: 'facebookUserFeedBehavior.js',
+      url: 'https://www.facebook.com',
+      infoURL: 'http://localhost:3030/info?url=https://www.facebook.com',
+      infoByNameURL: 'http://localhost:3030/info?name=facebookNewsFeed',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://www.facebook.com',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=facebookNewsFeed',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://www.facebook.com',
+      behaviorByNameURL: 'http://localhost:3030/behavior?name=facebookNewsFeed',
     },
-    url: 'https://www.facebook.com/Smithsonian/',
-  },
-  {
-    name: 'Instagram Post',
-    infoURL:
-      'http://localhost:3030/info?url=https://www.instagram.com/p/Bxiub6BB0Ab/',
-    infoByNameURL:
-      'http://localhost:3030/info?url=https://www.instagram.com/p/Bxiub6BB0Ab/',
-    behaviorURL: 'http://localhost:3030/behavior?name=instagramPostBehavior',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=instagramPostBehavior',
-    metadata: {
-      name: 'instagramPostBehavior',
-      match: {
-        regex: '^https:\\/\\/(www\\.)?instagram\\.com\\/p\\/[^\\/]+(?:\\/)?$',
+    {
+      name: 'Facebook Userfeed',
+      metadata: {
+        name: 'facebookUserFeed',
+        match: {
+          regex: '^https:\\/\\/(www\\.)?facebook\\.com\\/[^\\/]+\\/?$',
+        },
+        description:
+          'Views all items in the Facebook user/organization/artists/etc timeline',
+        fileName: 'facebookUserFeedBehavior.js',
       },
-      description:
-        "Views all the content on an instangram User's page: if the user has stories they are viewed, if a users post has image(s)/video(s) they are viewed, and all comments are retrieved",
-      fileName: 'instagramPostBehavior.js',
+      url: 'https://www.facebook.com/Smithsonian/',
+      infoURL:
+        'http://localhost:3030/info?url=https://www.facebook.com/Smithsonian/',
+      infoByNameURL: 'http://localhost:3030/info?name=facebookUserFeed',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://www.facebook.com/Smithsonian/',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=facebookUserFeed',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://www.facebook.com/Smithsonian/',
+      behaviorByNameURL: 'http://localhost:3030/behavior?name=facebookUserFeed',
     },
-    url: 'https://www.instagram.com/p/Bxiub6BB0Ab/',
-  },
-  {
-    name: 'Instagram User',
-    infoURL:
-      'http://localhost:3030/info?url=https://www.instagram.com/rhizomedotorg',
-    infoByNameURL:
-      'http://localhost:3030/info?url=https://www.instagram.com/rhizomedotorg',
-    behaviorURL: 'http://localhost:3030/behavior?name=instagramUserBehavior',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=instagramUserBehavior',
-    metadata: {
-      name: 'instagramUserBehavior',
-      match: {
-        regex:
-          '^https:\\/\\/(www\\.)?instagram\\.com\\/[^\\/]+(?:\\/(?:tagged(?:\\/)?)?)?$',
+    {
+      name: 'Instagram Post',
+      metadata: {
+        name: 'instagramPostBehavior',
+        match: {
+          regex: '^https:\\/\\/(www\\.)?instagram\\.com\\/p\\/[^\\/]+(?:\\/)?$',
+        },
+        description:
+          "Views all the content on an instangram User's page: if the user has stories they are viewed, if a users post has image(s)/video(s) they are viewed, and all comments are retrieved",
+        fileName: 'instagramPostBehavior.js',
       },
-      description:
-        "Views all the content on an instangram User's page: if the user has stories they are viewed, if a users post has image(s)/video(s) they are viewed, and all comments are retrieved",
-      fileName: 'instagramUserBehavior.js',
+      url: 'https://www.instagram.com/p/Bxiub6BB0Ab/',
+      infoURL:
+        'http://localhost:3030/info?url=https://www.instagram.com/p/Bxiub6BB0Ab/',
+      infoByNameURL: 'http://localhost:3030/info?name=instagramPostBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://www.instagram.com/p/Bxiub6BB0Ab/',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=instagramPostBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://www.instagram.com/p/Bxiub6BB0Ab/',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=instagramPostBehavior',
     },
-    url: 'https://www.instagram.com/rhizomedotorg',
-  },
-  {
-    name: 'Soundcloud Artist',
-    infoURL:
-      'http://localhost:3030/info?url=https://soundcloud.com/perturbator',
-    infoByNameURL:
-      'http://localhost:3030/info?url=https://soundcloud.com/perturbator',
-    behaviorURL: 'http://localhost:3030/behavior?name=soundCloudArtistBehavior',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=soundCloudArtistBehavior',
-    metadata: {
-      name: 'soundCloudArtistBehavior',
-      match: {
-        regex: '^(?:https:\\/\\/(?:www\\.)?)?soundcloud\\.com\\/[^\\/]+(\\/)?$',
+    {
+      name: 'Instagram User',
+      metadata: {
+        name: 'instagramUserBehavior',
+        match: {
+          regex:
+            '^https:\\/\\/(www\\.)?instagram\\.com\\/[^\\/]+(?:\\/(?:tagged(?:\\/)?)?)?$',
+        },
+        description:
+          "Views all the content on an instangram User's page: if the user has stories they are viewed, if a users post has image(s)/video(s) they are viewed, and all comments are retrieved",
+        fileName: 'instagramUserBehavior.js',
       },
-      description:
-        'Plays all tracks or collection of tracks by the artist, Once a track has been played, the next track is not played until network idle has been reached',
-      fileName: 'soundcloudArtistBehavior.js',
+      url: 'https://www.instagram.com/rhizomedotorg',
+      infoURL:
+        'http://localhost:3030/info?url=https://www.instagram.com/rhizomedotorg',
+      infoByNameURL: 'http://localhost:3030/info?name=instagramUserBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://www.instagram.com/rhizomedotorg',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=instagramUserBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://www.instagram.com/rhizomedotorg',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=instagramUserBehavior',
     },
-    url: 'https://soundcloud.com/perturbator',
-  },
-  {
-    name: 'Soundcloud Embed',
-    infoURL:
-      'http://localhost:3030/info?url=https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/598793067&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true',
-    infoByNameURL:
-      'http://localhost:3030/info?url=https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/598793067&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true',
-    behaviorURL: 'http://localhost:3030/behavior?name=soundCloudEmbedBehavior',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=soundCloudEmbedBehavior',
-    metadata: {
-      name: 'soundCloudEmbedBehavior',
-      match: {
-        regex: '^https:\\/\\/w\\.soundcloud\\.com\\/player\\/.+',
+    {
+      name: 'Soundcloud Artist',
+      metadata: {
+        name: 'soundCloudArtistBehavior',
+        match: {
+          regex:
+            '^(?:https:\\/\\/(?:www\\.)?)?soundcloud\\.com\\/[^\\/]+(\\/)?$',
+        },
+        description:
+          'Plays all tracks or collection of tracks by the artist, Once a track has been played, the next track is not played until network idle has been reached',
+        fileName: 'soundcloudArtistBehavior.js',
       },
-      description:
-        'Plays all tracks or collection of that are in the soundcloud embed. Once a track has been played, the next track is not played until network idle has been reached',
-      fileName: 'soundcloudEmbedBehavior.js',
+      url: 'https://soundcloud.com/perturbator',
+      infoURL:
+        'http://localhost:3030/info?url=https://soundcloud.com/perturbator',
+      infoByNameURL: 'http://localhost:3030/info?name=soundCloudArtistBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://soundcloud.com/perturbator',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=soundCloudArtistBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://soundcloud.com/perturbator',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=soundCloudArtistBehavior',
     },
-    url:
-      'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/598793067&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true',
-  },
-  {
-    name: 'Twitter Hashtags',
-    infoURL:
-      'http://localhost:3030/info?url=https://twitter.com/hashtag/iipcwac18?vertical=default&src=hash',
-    infoByNameURL:
-      'http://localhost:3030/info?url=https://twitter.com/hashtag/iipcwac18?vertical=default&src=hash',
-    behaviorURL: 'http://localhost:3030/behavior?name=twitterHashTagsBehavior',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=twitterHashTagsBehavior',
-    metadata: {
-      name: 'twitterHashTagsBehavior',
-      match: {
-        regex: '^(?:https:\\/\\/(?:www\\.)?)?twitter\\.com\\/hashtag\\/[^?]+.*',
+    {
+      name: 'Soundcloud Embed',
+      metadata: {
+        name: 'soundCloudEmbedBehavior',
+        match: {
+          regex: '^https:\\/\\/w\\.soundcloud\\.com\\/player\\/.+',
+        },
+        description:
+          'Plays all tracks or collection of that are in the soundcloud embed. Once a track has been played, the next track is not played until network idle has been reached',
+        fileName: 'soundcloudEmbedBehavior.js',
       },
-      description:
-        'For each tweet containing the searched hashtag views each tweet. If the tweet has a video it is played and a wait until network idle is done. If the tweet is a part of a thread or has replies views all related tweets',
-      fileName: 'twitterHashTagsBehavior.js',
+      url:
+        'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/598793067&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true',
+      infoURL:
+        'http://localhost:3030/info?url=https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/598793067&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true',
+      infoByNameURL: 'http://localhost:3030/info?name=soundCloudEmbedBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/598793067&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=soundCloudEmbedBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/598793067&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=soundCloudEmbedBehavior',
     },
-    url: 'https://twitter.com/hashtag/iipcwac18?vertical=default&src=hash',
-  },
-  {
-    name: 'Twitter Timeline',
-    infoURL:
-      'http://localhost:3030/info?url=https://twitter.com/webrecorder_io',
-    infoByNameURL:
-      'http://localhost:3030/info?url=https://twitter.com/webrecorder_io',
-    behaviorURL: 'http://localhost:3030/behavior?name=twitterTimelineBehavior',
-    behaviorByNameURL:
-      'http://localhost:3030/behavior?name=twitterTimelineBehavior',
-    metadata: {
-      name: 'twitterTimelineBehavior',
-      match: {
-        regex: '^(?:https:\\/\\/(?:www\\.)?)?twitter\\.com\\/[^\\/]+$',
+    {
+      name: 'Twitter Hashtags',
+      metadata: {
+        name: 'twitterHashTagsBehavior',
+        match: {
+          regex:
+            '^(?:https:\\/\\/(?:www\\.)?)?twitter\\.com\\/hashtag\\/[^?]+.*',
+        },
+        description:
+          'For each tweet containing the searched hashtag views each tweet. If the tweet has a video it is played and a wait until network idle is done. If the tweet is a part of a thread or has replies views all related tweets',
+        fileName: 'twitterHashTagsBehavior.js',
       },
-      description:
-        'For each tweet within the timeline views each tweet. If the tweet has a video it is played. If the tweet is a part of a thread or has replies views all related tweets',
-      fileName: 'twitterTimelineBehavior.js',
+      url: 'https://twitter.com/hashtag/iipcwac18?vertical=default&src=hash',
+      infoURL:
+        'http://localhost:3030/info?url=https://twitter.com/hashtag/iipcwac18?vertical=default&src=hash',
+      infoByNameURL: 'http://localhost:3030/info?name=twitterHashTagsBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://twitter.com/hashtag/iipcwac18?vertical=default&src=hash',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=twitterHashTagsBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://twitter.com/hashtag/iipcwac18?vertical=default&src=hash',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=twitterHashTagsBehavior',
     },
-    url: 'https://twitter.com/webrecorder_io',
+    {
+      name: 'Twitter Timeline',
+      metadata: {
+        name: 'twitterTimelineBehavior',
+        match: {
+          regex:
+            '^(?:https:[\\/]{2}(?:www[.])?)?twitter[.]com[\\/]?(?:[^\\/]+[\\/]?)?$',
+        },
+        description:
+          'For each tweet within the timeline views each tweet. If the tweet has a video it is played. If the tweet is a part of a thread or has replies views all related tweets',
+        fileName: 'twitterTimelineBehavior.js',
+      },
+      url: 'https://twitter.com/webrecorder_io',
+      infoURL:
+        'http://localhost:3030/info?url=https://twitter.com/webrecorder_io',
+      infoByNameURL: 'http://localhost:3030/info?name=twitterTimelineBehavior',
+      infoListURL:
+        'http://localhost:3030/info-list?url=https://twitter.com/webrecorder_io',
+      infoListByNameURL:
+        'http://localhost:3030/info-list?name=twitterTimelineBehavior',
+      behaviorURL:
+        'http://localhost:3030/behavior?url=https://twitter.com/webrecorder_io',
+      behaviorByNameURL:
+        'http://localhost:3030/behavior?name=twitterTimelineBehavior',
+    },
+  ],
+  defaultBMD: {
+    name: 'autoScrollBehavior',
+    defaultBehavior: true,
+    description:
+      'Scrolls the page until we can scroll no more. If media elements are discovered while scrolling they are played',
+    fileName: 'autoscrollBehavior.js',
   },
-];
+  allResult: {
+    url: 'http://localhost:3030/info-all',
+    count: 12,
+    value: {
+      defaultBehavior: {
+        name: 'autoScrollBehavior',
+        defaultBehavior: true,
+        description:
+          'Scrolls the page until we can scroll no more. If media elements are discovered while scrolling they are played',
+        fileName: 'autoscrollBehavior.js',
+      },
+      behaviors: {
+        deathImitatesLanguageBehavior: {
+          name: 'deathImitatesLanguageBehavior',
+          match: {
+            regex:
+              '^(?:https?:\\/\\/(?:www\\.)?)?deathimitateslanguage\\.harmvandendorpel\\.com\\/?$',
+          },
+          description:
+            'Scrolls the page clicking all the images rendered at the current scroll level',
+          fileName: 'deathImitatesLanguageBehavior.js',
+        },
+        pinterestBehavior: {
+          name: 'pinterestBehavior',
+          match: {
+            regex:
+              '^(?:https:\\/\\/(:?www\\.)?)pintrest\\.com\\/[a-zA-Z]+[?].+',
+          },
+          fileName: 'pinterestBehavior.js',
+        },
+        slideShareBehavior: {
+          name: 'slideShareBehavior',
+          match: {
+            regex:
+              '^(?:https:\\/\\/(?:www\\.)?)slideshare\\.net\\/[a-zA-Z]+[?].+',
+          },
+          description:
+            'Views each slide contained in the slide deck. If there are multiple slide decks each deck is viewed',
+          fileName: 'slideShareBehavior.js',
+        },
+        youtubeVideoBehavior: {
+          name: 'youtubeVideoBehavior',
+          match: {
+            regex: '^(?:https:\\/\\/(?:www\\.)?)?youtube\\.com\\/watch[?]v=.+',
+          },
+          description: 'Plays a YouTube video and loads all comments',
+          fileName: 'youtubeVideoBehavior.js',
+        },
+        facebookNewsFeed: {
+          name: 'facebookNewsFeed',
+          match: {
+            regex: '^https:\\/\\/(www\\.)?facebook\\.com(\\/)?([?]sk=nf)?$',
+          },
+          description: 'Views all items in the Facebook news feed',
+          fileName: 'facebookNewsFeedBehavior.js',
+        },
+        facebookUserFeed: {
+          name: 'facebookUserFeed',
+          match: {
+            regex: '^https:\\/\\/(www\\.)?facebook\\.com\\/[^\\/]+\\/?$',
+          },
+          description:
+            'Views all items in the Facebook user/organization/artists/etc timeline',
+          fileName: 'facebookUserFeedBehavior.js',
+        },
+        instagramPostBehavior: {
+          name: 'instagramPostBehavior',
+          match: {
+            regex:
+              '^https:\\/\\/(www\\.)?instagram\\.com\\/p\\/[^\\/]+(?:\\/)?$',
+          },
+          description:
+            "Views all the content on an instangram User's page: if the user has stories they are viewed, if a users post has image(s)/video(s) they are viewed, and all comments are retrieved",
+          fileName: 'instagramPostBehavior.js',
+        },
+        instagramUserBehavior: {
+          name: 'instagramUserBehavior',
+          match: {
+            regex:
+              '^https:\\/\\/(www\\.)?instagram\\.com\\/[^\\/]+(?:\\/(?:tagged(?:\\/)?)?)?$',
+          },
+          description:
+            "Views all the content on an instangram User's page: if the user has stories they are viewed, if a users post has image(s)/video(s) they are viewed, and all comments are retrieved",
+          fileName: 'instagramUserBehavior.js',
+        },
+        soundCloudArtistBehavior: {
+          name: 'soundCloudArtistBehavior',
+          match: {
+            regex:
+              '^(?:https:\\/\\/(?:www\\.)?)?soundcloud\\.com\\/[^\\/]+(\\/)?$',
+          },
+          description:
+            'Plays all tracks or collection of tracks by the artist, Once a track has been played, the next track is not played until network idle has been reached',
+          fileName: 'soundcloudArtistBehavior.js',
+        },
+        soundCloudEmbedBehavior: {
+          name: 'soundCloudEmbedBehavior',
+          match: {
+            regex: '^https:\\/\\/w\\.soundcloud\\.com\\/player\\/.+',
+          },
+          description:
+            'Plays all tracks or collection of that are in the soundcloud embed. Once a track has been played, the next track is not played until network idle has been reached',
+          fileName: 'soundcloudEmbedBehavior.js',
+        },
+        twitterHashTagsBehavior: {
+          name: 'twitterHashTagsBehavior',
+          match: {
+            regex:
+              '^(?:https:\\/\\/(?:www\\.)?)?twitter\\.com\\/hashtag\\/[^?]+.*',
+          },
+          description:
+            'For each tweet containing the searched hashtag views each tweet. If the tweet has a video it is played and a wait until network idle is done. If the tweet is a part of a thread or has replies views all related tweets',
+          fileName: 'twitterHashTagsBehavior.js',
+        },
+        twitterTimelineBehavior: {
+          name: 'twitterTimelineBehavior',
+          match: {
+            regex:
+              '^(?:https:[\\/]{2}(?:www[.])?)?twitter[.]com[\\/]?(?:[^\\/]+[\\/]?)?$',
+          },
+          description:
+            'For each tweet within the timeline views each tweet. If the tweet has a video it is played. If the tweet is a part of a thread or has replies views all related tweets',
+          fileName: 'twitterTimelineBehavior.js',
+        },
+      },
+    },
+  },
+};

--- a/test/test-behavior-api.js
+++ b/test/test-behavior-api.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import rp from 'request-promise-native';
 import startServer from './helpers/testServer';
-import TestedValues from './helpers/testedValues';
+import { tests, allResult, defaultBMD } from './helpers/testedValues';
 import { loadBehavior } from './helpers/utils';
 
 /**
@@ -18,8 +18,7 @@ test.after.always(t => {
   return server.close();
 });
 
-for (let i = 0; i < TestedValues.length; i++) {
-  const aTest = TestedValues[i];
+for (const aTest of tests) {
   test(`Retrieving the behavior js for "${
     aTest.name
   }" by URL should work`, async t => {
@@ -59,4 +58,54 @@ for (let i = 0; i < TestedValues.length; i++) {
     const expectedInfo = aTest.metadata;
     t.deepEqual(response, expectedInfo);
   });
+
+  test(`Retrieving the behavior info-list for "${
+    aTest.name
+  }" by URL should work`, async t => {
+    const response = await rp({
+      method: 'GET',
+      uri: aTest.infoListURL,
+      json: true,
+    });
+    const expectedInfo = aTest.metadata;
+    if (response.length === 1) {
+      t.deepEqual(response, [expectedInfo]);
+    } else {
+      t.deepEqual(response, [expectedInfo, defaultBMD]);
+    }
+  });
+
+  test(`Retrieving the behavior info-list for "${
+    aTest.name
+  }" by name should work`, async t => {
+    const response = await rp({
+      method: 'GET',
+      uri: aTest.infoListByNameURL,
+      json: true,
+    });
+    const expectedInfo = aTest.metadata;
+    if (response.length === 1) {
+      t.deepEqual(response, [expectedInfo]);
+    } else {
+      t.deepEqual(response, [expectedInfo, defaultBMD]);
+    }
+  });
 }
+
+test('Retrieving all behavior info should work', async t => {
+  const {
+    url,
+    value: { defaultBehavior, behaviors },
+    count,
+  } = allResult;
+  const response = await rp({
+    method: 'GET',
+    uri: url,
+    json: true,
+  });
+  t.deepEqual(response.defaultBehavior, defaultBehavior);
+  t.is(response.behaviors.length, count);
+  for (const b of response.behaviors) {
+    t.deepEqual(b, behaviors[b.name]);
+  }
+});


### PR DESCRIPTION
api: fixed issue with info-list API endpoint returning duplicate valu…es for the default behavior
behaviors: expanded the twitter timeline behavior to match a signed in users timeline twitter.com/?
behaviors: added defaulting to the autoscroll behavior if twitter behaviors find no tweets
tests: added tests covering API endpoints /info-list and /info-all